### PR TITLE
fix jsr exports & fix esm build

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -1,5 +1,5 @@
 {
   "name": "@dynimorius/color-utilities",
   "version": "1.0.7",
-  "exports": "./lib/esm/public_api.js"
+  "exports": "./src/public_api.ts"
 }

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "module": "CommonJS",
+    "module": "ES2020",
     "outDir": "./lib/esm",
     "target": "ES2020",
   }


### PR DESCRIPTION
This is a wonderful package, but the esm build is actually commonjs, in addition, on JSR you can just directly export typescript, JSR handles the rest :)