### PR TITLE
Update package.json to add delta-e keyword

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "chromatic adaptation",
     "color difference",
     "delta e",
+    "delta-e",
     "RGB",
     "RGBA",
     "sRBG",


### PR DESCRIPTION
Thanks for making and sharing this high-quality color library, @dynimorius!

I was looking for an alternative to [delta-e](https://www.npmjs.com/package/delta-e) with better TypeScript support, and your package works flawlessly.

Hopefully this change will make your package end up just a little higher in the search results of npmjs.com, so more others will benefit from your work 😀