### PR TITLE
fix: specify `types` in `package.json` `exports` section

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "module": "./lib/esm/public_api.js",
   "exports": {
     ".": {
-      "import": "./lib/esm/public_api.js"
+      "import": "./lib/esm/public_api.js",
+      "types": "./lib/types/index.d.ts"
     }
   },
   "files": [


### PR DESCRIPTION
Avoid the following error when using the following `tsconfig.json` settings:

```json
{
  "compilerOptions": {
    "module": "Preserve",
    "moduleResolution": "Bundler",
  }
}
```

Error:

```log
../tokens-lib/src/color-util.ts:4:57 - error TS7016: Could not find a declaration file for module '@dynamize/color-utilities'. '~/project/node_modules/.pnpm/@dynamize+color-utilities@1.0.11/node_modules/@dynamize/color-utilities/lib/esm/public_api.js' implicitly has an 'any' type.
  There are types at '~/project/packages/tokens-lib/node_modules/@dynamize/color-utilities/lib/types/public_api.d.ts', but this result could not be resolved when respecting package.json "exports". The '@dynamize/color-utilities' library may need to update its package.json or typings.
```